### PR TITLE
[API] patch and get all user creds. New userIdentifier term added.

### DIFF
--- a/docs/api-overview.mdx
+++ b/docs/api-overview.mdx
@@ -283,7 +283,7 @@ The resultant credential `id` remains the same, so after a 200 HTTP response cod
 
 > Patch all previously issued <Tip type="credentials"/> by your brand to a user.
 
-**Method**: `GET` <br />
+**Method**: `PATCH` <br />
 **Path**: `/userCredentials/{userIdentifier}`
 
 A <Tip type="userIdentifier"/> is either a phone number or email address associated with a user.
@@ -304,7 +304,7 @@ This endpoint all modifies credentials issued to the user by your brand.
 
 #### Response Body:
 
-```typescript title="UserCredentialsPatchDto"
+```typescript title="UserCredentialsDto"
 { 
   "credentials": {
     "id": string, // credential id
@@ -318,5 +318,43 @@ This endpoint all modifies credentials issued to the user by your brand.
 ```
 
 The response body contains a list of all credentials that were modified on the `credentials` key.
+
+---
+
+### Get All User Credentials
+
+> Get all previously issued <Tip type="credentials"/> by your brand to a user.
+
+**Method**: `GET` <br />
+**Path**: `/userCredentials/{userIdentifier}`
+
+A <Tip type="userIdentifier"/> is either a phone number or email address associated with a user.
+
+:::note
+This endpoint all modifies credentials issued to the user by your brand.
+:::
+
+:::caution
+It should be clear that this endpoint should not be used in place of [`/hasMatchingCredentials`](/api-overview/#check-user-credentials), which can check user credentials across many issuers but does not return the credentials' values. 
+
+This endpoint is simply a nice to have for an issuer to see all credentials they have issued to a user.
+:::
+
+#### Response Body:
+
+```typescript title="UserCredentialsDto"
+{ 
+  "credentials": {
+    "id": string, // credential id
+    "type": string, // credential type
+    "data": Map<string, any> // credential data map that matches your provided data and the credential type's JSON Schema definition
+    "issuanceDate": string, // when credential was created as a milliseconds since epoch unix timestamp
+    "expirationDate?": number, // when the credential expires as a milliseconds since epoch unix timestamp; optional
+    "status": 'valid' | 'revoked' // an enum to denote whether the credential is valid (all credentials are valid when first issued) — note that this is independent of the expirationDate.
+  }[]
+}
+```
+
+The response body contains a list of all credentials on the `credentials` key.
 
 ---

--- a/docs/api-overview.mdx
+++ b/docs/api-overview.mdx
@@ -229,14 +229,14 @@ The created and issued credentials contains an `id` that you should store. You'l
 
 ---
 
-### Patch Credentials
+### Patch Credential
 
 > Patch a previously issued <Tip type="credential"/>.
 
 **Method**: `PATCH` <br />
 **Path**: `/credentials/{id}`
 
-You can optionally provide all of the following:
+You can optionally provide any of the following in the request body:
 
 1. (Optional) new credential data
 2. (Optional) new credential expiration date
@@ -276,5 +276,47 @@ Credential data is stored securely via a data privacy vault that encrypts and to
 ```
 
 The resultant credential `id` remains the same, so after a 200 HTTP response code is received, nothing further needs to be updated on your end.
+
+---
+
+### Patch All User Credentials
+
+> Patch all previously issued <Tip type="credentials"/> by your brand to a user.
+
+**Method**: `GET` <br />
+**Path**: `/userCredentials/{userIdentifier}`
+
+A <Tip type="userIdentifier"/> is either a phone number or email address associated with a user.
+
+The only credential value that can by updated in this manner is `status`. A credential status must be in the request body.
+
+:::note
+This endpoint all modifies credentials issued to the user by your brand.
+:::
+
+#### Request Body
+
+```typescript
+{
+  "status": 'valid' | 'revoked' // an enum to denote whether the credential is valid (all credentials are valid when first issued) — note that this is independent of the expirationDate
+}
+```
+
+#### Response Body:
+
+```typescript title="UserCredentialsPatchDto"
+{ 
+  "credentials": {
+    "id": string, // credential id
+    "type": string, // credential type
+    "data": Map<string, any> // credential data map that matches your provided data and the credential type's JSON Schema definition
+    "issuanceDate": string, // when credential was created as a milliseconds since epoch unix timestamp
+    "expirationDate?": number, // when the credential expires as a milliseconds since epoch unix timestamp; optional
+    "status": 'valid' | 'revoked' // an enum to denote whether the credential is valid (all credentials are valid when first issued) — note that this is independent of the expirationDate.
+  }[]
+}
+```
+
+The response body contains a list of all credentials that were modified on the `credentials` key.
 
 ---

--- a/docs/terminology.mdx
+++ b/docs/terminology.mdx
@@ -149,6 +149,18 @@ Users can be referenced by email and/or phone, identifiers that you already have
 }
 ```
 
+### User Identifier
+
+> A **userIdentifier** is a value used to refer to an user. Due to the ubiquitous nature of `phone` and/or `email` values being associated with <a href="/terminology#user">users</a> we have adopted to this term to refer to either of these values.
+
+:::note
+A user can have many userIdentifiers of email and phones. 
+:::
+
+**Example:** richard@pipedpiper.net is one of Richard Hendrick's user identifiers. He also has a phone number of +10123456789, another one of his user identifiers.
+
+**Components:** We have abstracted away the complexity of dealing with a third party uuid to refer to a user. Instead, you can use the user's email or phone number to refer to and issue credentials to users in our system.
+
 ### Brand
 
 > A **brand** is a customer entity that has a corresponding unique API key, name, and ID card image. Brands can issue, request and receive <a href="/terminology#credential">credentials</a> to and from <a href="/terminology#user">users</a>.

--- a/src/components/Tip.jsx
+++ b/src/components/Tip.jsx
@@ -71,7 +71,7 @@ const tooltips =  {
     "user":
     <>
     <div>
-        <b>A <a href="/terminology#user">user</a> is an individual in the Verified Inc. network.</b> Each user has at least one phone or emails associated with them. They can have multiple of either.
+        <b>A <a href="/terminology#user">user</a> is an individual in the Verified Inc. network.</b> Each user has at least one phone or emails, aka <a href="/terminology#user-identifier">userIdentifiers</a> associated with them. They can have multiple of either.
     </div>
     <Collapsible trigger="+ More..." triggerWhenOpen="- Less">
         <div>
@@ -79,6 +79,20 @@ const tooltips =  {
         </div>
         <div>
             <b>Components:</b> Referenced in API endpoints `/hasMatchingCredentials` and `/issueCredentials`. User data is associated by using these user identifiers that you already keep on your users.
+        </div>
+    </Collapsible>
+    </>,
+    "userIdentifier":
+    <>
+    <div>
+        <b>A <a href="/terminology#user-identifier">userIdentifier</a> is an email or phone value</b> which is associated with a <a href="/terminology#user">user</a>.
+    </div>
+    <Collapsible trigger="+ More..." triggerWhenOpen="- Less">
+        <div>
+            <b>Example:</b> richard@pipedpiper.net is one of Richard Hendrick's user identifiers. He also has a phone number of +10123456789, another one of his user identifiers.
+        </div>
+        <div>
+            <b>Components:</b> We have abstracted away the complexity of dealing with a third party uuid to refer to a user. Instead, you can use the user's email or phone number to refer to and issue credentials to users in our system.
         </div>
     </Collapsible>
     </>,


### PR DESCRIPTION
## Summary
Added information on the new api endpoints to patch all and get all user credentials by user identifiers. Also, added a new terms section for what a user identifier is to make things more clear. 

## Changes
- [API] patch all creds
- [API get all creds
- terminology userIdentifers and Tip section added

## Testing
- locally
- https://resilient-capybara-2fa074.netlify.app/

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [x] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [x] Any dependent changes have been merged and published in upstream projects. Waiting on https://github.com/UnumID/core-service/pull/169 to be merged and released. Please do not not merge until that is done (but please review and approve)