### PR TITLE
[hasMatchingCredentials] credentialRequests made optional

### DIFF
--- a/docs/api-overview.mdx
+++ b/docs/api-overview.mdx
@@ -68,9 +68,9 @@ Jump to:
 
 You need to provide:
 
-1. Credential request(s)
-2. User's email or phone
-3. (Optional) Partner UUID. _More information on the partner UUID use case can be found in the [Issuance Guide](/issuance-guide#partner-issuance)._
+1. User's email or phone
+2. (Optional) Credential request(s). _Required if Partner UUID is not provided._
+3. (Optional) Partner UUID. _More information on the partner UUID use case can be found in the [Issuance Guide](/issuance-guide#already-issued-credentials)._
 
 A credential requests encodes which <Tip type="credential">credentials</Tip> you're asking the user to share with your <Tip type="brand"/>. It's a list of one or more [`CredentialRequest`](https://docs.verified.inc/types/interfaces/credentialrequest.html) objects.
 
@@ -84,7 +84,10 @@ A credential requests encodes which <Tip type="credential">credentials</Tip> you
 
 If you list multiple <Tip type="issuer">issuers</Tip>, the user can include a credential issued by _any one_ of those listed. If `issuers` is left empty the user can include a credential with matching type issued by _any_ issuer.
 
-2. user's email or phone
+:::note
+The Credential <Tip type="request">requests</Tip> attribute is required if a Partner UUID is not provided. If Partner UUID is provided, it is not used. Instead, a pre-defined set of accepting partner's credentials requests are used.
+_More information on the partner UUID use case can be found in the [Issuance Guide](/issuance-guide#already-issued-credentials)._
+:::
 
 :::caution
 The same ApiKey necessary to call /hasMatchingCredentials grants you and only you access to the encrypted credential data documented in [Get Shared Credentials](#get-shared-credentials). Please keep this key secure.
@@ -94,9 +97,9 @@ The same ApiKey necessary to call /hasMatchingCredentials grants you and only yo
 
 ```typescript
 {
-  credentialRequests: CredentialRequest[], // a list of one or more CredentialRequest objects. Encodes which credentials are being asked for.
   email?: string, // user's email address; optional if phone is provided
   phone?: string, // user's phone number; optional if email is provided
+  credentialRequests: CredentialRequest[], // a list of one or more CredentialRequest objects. Encodes which credentials are being asked for; not used if partnerUuid is provided
   partnerUuid?: string // partner's uuid; optional
 }
 ```

--- a/docs/api-overview.mdx
+++ b/docs/api-overview.mdx
@@ -85,7 +85,7 @@ A credential requests encodes which <Tip type="credential">credentials</Tip> you
 If you list multiple <Tip type="issuer">issuers</Tip>, the user can include a credential issued by _any one_ of those listed. If `issuers` is left empty the user can include a credential with matching type issued by _any_ issuer.
 
 :::note
-The Credential <Tip type="request">requests</Tip> attribute is required if a Partner UUID is not provided. If Partner UUID is provided, it is not used. Instead, a pre-defined set of accepting partner's credentials requests are used.
+The Credential <Tip type="request">requests</Tip> attribute is required if a Partner UUID is **not** provided. If Partner UUID is provided, the Credential requests attribute is not used. Instead, a pre-defined set of accepting partner's credentials requests are used.
 _More information on the partner UUID use case can be found in the [Issuance Guide](/issuance-guide#already-issued-credentials)._
 :::
 

--- a/docs/issuance-guide.mdx
+++ b/docs/issuance-guide.mdx
@@ -168,7 +168,7 @@ If the user does not complete the partner onboarding process within 5 minutes, t
 If this is an experience you would like to provide for your partners immediately after credential issuance, please let us know so we can provide you with your partner's static UUID and enable this capability for your <Tip type="brand">brand</Tip>.
 
 #### Already Issued Credentials
-If you have already issued credentials to a user, then [`/hasMatchingCredentials`](/api-overview#check-user-credentials) can be called with `partnerUuid`. In this case, if Verified Inc. can confirm the user has credentials to satisfy the credential request(s) in the request body, then the resulting API response body will contain a `url` which you should redirect the user to. 
+If you have already issued credentials to a user, then [`/hasMatchingCredentials`](/api-overview#check-user-credentials) can be called with `partnerUuid`. In this case, if Verified Inc. can confirm the user has credentials to satisfy the [pre-defined](/acceptance-guide#partner-acceptance) partner credential request(s), then the resulting API response body will contain a `url` which you should redirect the user to. 
 Just as in the case of the [`/credentials`](/api-overview#issue-credentials) response, this `url` ultimately redirects the user to a page of the partner's choosing. However, the `url` first directs the user to the Verified Inc. wallet, where they explicitly consent to share credential data with the partner.
 
 ```json title="Example Check has Matching Credentials Response"


### PR DESCRIPTION
[Ticket](https://trello.com/c/WkzhOcgQ/5426-remove-need-for-credentialrequests-in-hasmatchingcredentials-calls-with-partneruuuid)

## Summary
Documentation updated with mentioned of `partnerUuid` making `credentialRequests` not needed in /hasMatchingCredentials.

## Changes
- issuance guide
- api docs

## Testing
- n/a

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [x] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [x] Any dependent changes have been merged and published in upstream projects