### PR TITLE
[Schema] format information mentioned. Open-sourced sdk mentioned as well

### DIFF
--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -79,21 +79,22 @@ Response body from https://schema.verified.inc/jsonSchema/AddressCredential:
 You can instead just use the `/jsonSchema` path to only get that information, e.g. https://schema.verified.inc/jsonSchema/FirstNameCredential:
 ```json title="Example FirstNameCredential JSON Schema"
 {
-    "$id": "FirstNameCredential",
+    "$id": "AddressCredential",
     "additionalProperties": false,
     "type": "object",
     "properties": {
-        "firstName": {
-            "description": "A person's first name",
+        "address": {
+            "format": "address",
+            "description": "Address in the format of: street, city, iso3166-code postal-code",
             "examples": [
-                "John",
-                "Mary Kate"
+                "10 Downing Street, London, GB-ENG SW1A 2AA",
+                "307 3rd Ave, Apt #4, San Austin, US-GA 18025-9876"
             ],
             "type": "string"
         }
     },
     "required": [
-        "firstName"
+        "address"
     ]
 }
 ```

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -31,7 +31,7 @@ We hope to soon make it possible for you as a <a href="/terminology#customer"><T
 We currently are opting to only support what can be referred to as "single attribute atomic credentials". This means that we break data into its simplest form for every credential. This is to provide users a means of selective disclosure for <a href="/terminology#request"><Tip type="request"/></a>s with optional fields.
 
 #### JSON Schema
-The `/schema` path will return enriched schema information, however likely the only relevant schema section will the the `json` key which contains the JSON schema definition.
+The `/schema` path will return enriched schema information. Likely the relevant section for your use is the `json` key, which contains the JSON schema definition.
 
 Response body from https://schema.verified.inc/jsonSchema/AddressCredential:
 ```json title="Example AddressCredential Schema"

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -12,7 +12,7 @@ import Tip from '../src/components/Tip';
 
 Verified Inc. enables securely sharing verified <a href="/terminology#credential"><Tip type="credential"/></a> data amongst network participants. While in theory this data can take any shape, a structured schema must be defined and followed for every credential type for the sake of all network participants.
 
-We use [JSON Schema](https://json-schema.org/) syntax for data validation purposes via a pre-compiled [AJV](https://ajv.js.org/guide/why-ajv.html) engine. We feel this meets our goal to have a credential schema definition that is robust enough to encapsulate and define any data with the property of being easily described, displayed, and validated.
+We use [JSON Schema](https://json-schema.org/) syntax for data validation purposes via a pre-compiled [AJV](https://ajv.js.org/guide/why-ajv.html) engine. This ensures our credential schemas are robust enough to encapsulate any data while still being easily described, displayed, and validated.
 
 ### Schema Definitions
 

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -104,7 +104,7 @@ Note that each attribute has a `description` and `examples` to help you understa
 
 ## Example
 
-After first grabbing the JSON schemas for the Address, FirstName, and LastName Credentials and understand their attribute's description and examples, we can create compliant credential bodies.
+First, we get the JSON schemas for the [`AddressCredential`](https://schema.verified.inc/jsonSchema/AddressCredential), [`FirstNameCredential`](https://schema.verified.inc/jsonSchema/FirstNameCredential), and [`LastNameCredential`](https://schema.verified.inc/jsonSchema/LastNameCredential) and review their attributes' `description`s and `examples`.
 
 Next, we construct valid credential bodies, according to the schemas:
 

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -106,7 +106,7 @@ Note that each attribute has a `description` and `examples` to help you understa
 
 After first grabbing the JSON schemas for the Address, FirstName, and LastName Credentials and understand their attribute's description and examples, we can create compliant credential bodies.
 
-Below is code level example of those credentials with valid values being constructed for credential issuance. In this example we are following the [AddressCredential](https://schema.verified.inc/jsonSchema/AddressCredential), [FirstNameCredential](https://schema.verified.inc/jsonSchema/FirstNameCredential), and [LastNameCredential](https://schema.verified.inc/jsonSchema/LastNameCredential) JSON schemas.
+Next, we construct valid credential bodies, according to the schemas:
 
 ```typescript
 /*The credential data compliant with the Address, FirstName, and LastName Credentials schemas*/

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -12,11 +12,7 @@ import Tip from '../src/components/Tip';
 
 Verified Inc. enables securely sharing verified <a href="/terminology#credential"><Tip type="credential"/></a> data amongst network participants. While in theory this data can take any shape, a structured schema must be defined and followed for every credential type for the sake of all network participants.
 
-We opted to format our data using W3C's [Linked Data](https://www.w3.org/standards/semanticweb/data) serialized via [JSON-LD](https://www.w3.org/TR/json-ld11/). It gives us the structure to define human readable vocabulary around the data. We use [JSON Schema](https://json-schema.org/) syntax defined via [Typebox](https://github.com/sinclairzx81/typebox) for our data validation purposes via a pre-compiled [AJV](https://ajv.js.org/guide/why-ajv.html) engine. We feel this meets our goal to have a credential schema definition that is robust enough to encapsulate and define any data with the property of being easily described, displayed, and validated.
-
-### Context File
-
-Our entire human readable JSON-LD [context](https://www.w3.org/TR/json-ld11/#the-context) semantics file can be download and viewed via https://schema.verified.inc/context. The context file serves as a building block for the basis of the shared vocabulary that ultimately makes up our credential data schemas. However, more than likely what you want to know is the schema for a particular credential type.
+We use [JSON Schema](https://json-schema.org/) syntax for data validation purposes via a pre-compiled [AJV](https://ajv.js.org/guide/why-ajv.html) engine. We feel this meets our goal to have a credential schema definition that is robust enough to encapsulate and define any data with the property of being easily described, displayed, and validated.
 
 ### Schema Definitions
 
@@ -29,37 +25,117 @@ It is possible to view the response bodies from https://schema.verified.inc/sche
 :::
 
 :::important
-Given use of JSON Schema and JSON-LD standards for schema definitions, we hope to make <a href="/terminology#customer"><Tip type="customer"/></a> defined credentials schemas a reality very soon. However, until then, all credential types have schemas defined by Verified Inc.. Please let us know if you would like to define a new credential schema for your use case.
+Given use of JSON Schema standard for schema definitions, we hope to make <a href="/terminology#customer"><Tip type="customer"/></a> defined credentials schemas a reality very soon. However, until then, all credential types have schemas defined by Verified Inc.. Please let us know if you would like to define a new credential schema for your use case.
 :::
 
 We currently are opting to only support what can be referred to as "single attribute atomic credentials". This means that we break data into its simplest form for every credential. This is to provide users a means of selective disclosure for <a href="/terminology#request"><Tip type="request"/></a>s with optional fields.
 
+#### JSON Schema
+The `/schema` path will return enriched schema information, however likely the only relevant schema section will the the `json` key which contains the JSON schema definition.
+
+Response body from https://schema.verified.inc/jsonSchema/AddressCredential:
+```json title="Example AddressCredential Schema"
+{
+    // highlight-start
+    "json": {
+        "$id": "AddressCredential",
+        "additionalProperties": false,
+        "type": "object",
+        "properties": {
+            "address": {
+                "format": "address",
+                "description": "Address in the format of: street, city, iso3166-code postal-code",
+                "examples": [
+                    "10 Downing Street, London, GB-ENG SW1A 2AA",
+                    "307 3rd Ave, Apt #4, San Austin, US-GA 18025-9876"
+                ],
+                "type": "string"
+            }
+        },
+        "required": [
+            "address"
+        ]
+    },
+    // highlight-end
+    "jsonLD": {
+        "@type": "AddressCredential",
+        "address": "schema:address",
+        "@context": "https://schema.unumid.co"
+    },
+    "attributes": {
+        "type": "AddressCredential",
+        "attributes": [
+            {
+                "key": "address",
+                "label": "Address",
+                "comment": "Physical address.",
+                "displayFormat": "Address"
+            }
+        ]
+    }
+}
+```
+
+You can instead just use the `/jsonSchema` path to only get that information, e.g. https://schema.verified.inc/jsonSchema/FirstNameCredential:
+```json title="Example FirstNameCredential JSON Schema"
+{
+    "$id": "FirstNameCredential",
+    "additionalProperties": false,
+    "type": "object",
+    "properties": {
+        "firstName": {
+            "description": "A person's first name",
+            "examples": [
+                "John",
+                "Mary Kate"
+            ],
+            "type": "string"
+        }
+    },
+    "required": [
+        "firstName"
+    ]
+}
+```
+
+:::tip
+You will notice that each attribute will have a `description` and `examples` to assist your understanding of the credential's schema. If more detailed information is required our [schema-sdk](https://github.com/UnumID/schema-sdk) is open-sourced and our [formats](https://github.com/UnumID/schema-sdk/blob/main/src/formats.ts) are free to be analyzed.
+:::
+
 ## Example
 
-Below is code level example of how to comply with the schema definitions when issuing credentials. In this example we are following the [AddressCredential](https://schema.verified.inc/schema/AddressCredential) and [FullNameCredential](https://schema.verified.inc/schema/FullNameCredential) schemas.
+After first grabbing the JSON schemas for the Address, FirstName, and LastName Credentials and understand their attribute's description and examples, we can create compliant credential bodies.
+
+Below is code level example of those credentials with valid values being constructed for credential issuance. In this example we are following the [AddressCredential](https://schema.verified.inc/jsonSchema/AddressCredential), [FirstNameCredential](https://schema.verified.inc/jsonSchema/FirstNameCredential), and [LastNameCredential](https://schema.verified.inc/jsonSchema/LastNameCredential) JSON schemas.
 
 ```typescript
-/*The credential data compliant with the Address and FullName Credentials schemas*/
+/*The credential data compliant with the Address, FirstName, and LastName Credentials schemas*/
 const credentialsList: Credentials = [
   {
     type: 'AddressCredential',
     data: {
-      address: '1010 Main St, Anytown USA',
+      address: '1010 Main St, San Francisco, US-CA 94117',
     },
   },
   {
-    type: 'FullNameCredential',
+    type: 'FirstNameCredential',
     data: {
-      fullName: 'John Red Doe',
+      fullName: 'Richard',
     },
   },
+  {
+    type: 'LastNameCredential',
+    data: {
+      fullName: 'Hendricks',
+    },
+  }
 ];
 ```
 
 ```typescript title="Example Request Body for Issuing Credentials"
 {
   "credentials": credentialsList, // a list of one or more Credentials objects
-  "email": "john@reddoe.co"
+  "email": "richard.hendricks@pipedpiper.net"
 }
 
 ```

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -25,7 +25,7 @@ It is possible to view the response bodies from https://schema.verified.inc/sche
 :::
 
 :::important
-Given use of JSON Schema standard for schema definitions, we hope to make <a href="/terminology#customer"><Tip type="customer"/></a> defined credentials schemas a reality very soon. However, until then, all credential types have schemas defined by Verified Inc.. Please let us know if you would like to define a new credential schema for your use case.
+We hope to soon make it possible for you as a <a href="/terminology#customer"><Tip type="customer"/></a> to define your own credential schemas. But **currently, we Verified Inc. define all credential schemas.** If you would like a new credential schema for your use case, please let us know and we will gladly define one for you.
 :::
 
 We currently are opting to only support what can be referred to as "single attribute atomic credentials". This means that we break data into its simplest form for every credential. This is to provide users a means of selective disclosure for <a href="/terminology#request"><Tip type="request"/></a>s with optional fields.

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -100,7 +100,7 @@ You can instead just use the `/jsonSchema` path to only get that information, e.
 ```
 
 :::tip
-Note that each attribute has a `description` and `examples` to help you understand the credential's schema. If you need more detailed information, look at our open source [schema-sdk](https://github.com/UnumID/schema-sdk) and [formats](https://github.com/UnumID/schema-sdk/blob/main/src/formats.ts).
+Note that each attribute has a `description` and `examples` to help you understand the credential's schema. If you need more detailed information, look at our open source [schema-sdk](https://github.com/UnumID/schema-sdk) [formats](https://github.com/UnumID/schema-sdk/blob/main/src/formats.ts).
 :::
 
 ## Example

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -99,7 +99,7 @@ You can instead just use the `/jsonSchema` path to only get that information, e.
 ```
 
 :::tip
-You will notice that each attribute will have a `description` and `examples` to assist your understanding of the credential's schema. If more detailed information is required our [schema-sdk](https://github.com/UnumID/schema-sdk) is open-sourced and our [formats](https://github.com/UnumID/schema-sdk/blob/main/src/formats.ts) are free to be analyzed.
+Note that each attribute has a `description` and `examples` to help you understand the credential's schema. If you need more detailed information, look at our open source [schema-sdk](https://github.com/UnumID/schema-sdk) and [formats](https://github.com/UnumID/schema-sdk/blob/main/src/formats.ts).
 :::
 
 ## Example

--- a/docs/schema.mdx
+++ b/docs/schema.mdx
@@ -77,7 +77,7 @@ Response body from https://schema.verified.inc/jsonSchema/AddressCredential:
 ```
 
 You can instead just use the `/jsonSchema` path to only get that information, e.g. https://schema.verified.inc/jsonSchema/FirstNameCredential:
-```json title="Example FirstNameCredential JSON Schema"
+```json title="Example AddressCredential JSON Schema"
 {
     "$id": "AddressCredential",
     "additionalProperties": false,


### PR DESCRIPTION
## Summary
Adding some schema examples to the schema docs. Also now mentioning the open source schema-sdk repo and our new `description` and `example` attributes to assist in format understanding.

## Changes
- more schema examples
- schema-sdk repo mentioned

## Testing
- locally
- deployed to preview https://resilient-capybara-2fa074.netlify.app/

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [x] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [x] Any dependent changes have been merged and published in upstream projects