### PR TITLE
chore: add description for presentation requests

### DIFF
--- a/docs/api-overview.mdx
+++ b/docs/api-overview.mdx
@@ -95,7 +95,8 @@ The same ApiKey necessary to call /hasMatchingCredentials grants you and only yo
   email?: string, // user's email address; optional if phone is provided
   phone?: string, // user's phone number; optional if email is provided
   credentialRequests: CredentialRequest[], // a list of one or more CredentialRequest objects. Encodes which credentials are being asked for; not used if partnerUuid is provided
-  partnerUuid?: string // partner's uuid; optional
+  partnerUuid?: string, // partner's uuid; optional
+  description?: string // the description that goes to the consent page header, when is empty the default text will be used.
 }
 ```
 

--- a/docs/api-overview.mdx
+++ b/docs/api-overview.mdx
@@ -96,7 +96,7 @@ The same ApiKey necessary to call /hasMatchingCredentials grants you and only yo
   phone?: string, // user's phone number; optional if email is provided
   credentialRequests: CredentialRequest[], // a list of one or more CredentialRequest objects. Encodes which credentials are being asked for; not used if partnerUuid is provided
   partnerUuid?: string, // partner's uuid; optional
-  description?: string // the description that goes to the consent page header, when is empty the default text will be used.
+  description?: string // A description displayed in the consent page header. If no description is provided, a default value will be displayed.
 }
 ```
 

--- a/docs/terminology.mdx
+++ b/docs/terminology.mdx
@@ -91,7 +91,7 @@ The full details of the request object aren't that important or helpful to know,
   "updatedAt": "1673470082200",
   "email": "test@verified.inc",
   "phone": null,
-  "description": "You are being requested with the following information:",
+  "description": "Please share the following information:",
   // highlight-start
   "credentialRequests": [
     {

--- a/docs/terminology.mdx
+++ b/docs/terminology.mdx
@@ -91,6 +91,7 @@ The full details of the request object aren't that important or helpful to know,
   "updatedAt": "1673470082200",
   "email": "test@verified.inc",
   "phone": null,
+  "description": "You are being requested with the following information:",
   // highlight-start
   "credentialRequests": [
     {


### PR DESCRIPTION
[Ticket](https://trello.com/c/IS0liH1W/5654-add-explanation-text-at-top-of-request-defined-in-the-presentation-request-update-request-page-design)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
Added the new description for presentation requests, by updaing the request body for hasMatchingCredentials.

## Changes
- updated api-overview
- updated terminology

## Testing
Tested locally.

## Demo

![Screenshot 2023-07-24 at 09 54 03](https://github.com/UnumID/UnumID.github.io/assets/13892132/726f94a3-fe9d-4283-af63-5e1c377df04b)
![Screenshot 2023-07-24 at 09 54 18](https://github.com/UnumID/UnumID.github.io/assets/13892132/9b98cc3b-b9ea-4ad2-a72a-10b1c9447634)


## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects
