### PR TITLE
[ApiKey] updated to be the Hooli Docs brand as indicated in the Sandbox db.

### DIFF
--- a/docs/1-click-or-free-use-case.mdx
+++ b/docs/1-click-or-free-use-case.mdx
@@ -18,7 +18,7 @@ import TabItem from '@theme/TabItem';
 You will need an API key and an email and/or phone for each user. Below is a valid API Key for your initial usage along with suggested test email and phone values.
 
 ```json title="Sandbox API Key"
-5YugDQgjPn2LG2xTAs/+c6Kfrf7Ie45PIGjJurP8vNk=
+yVg3LEnF08y0MDmpHcPxB+sZWFcDARmPRKdY2M906ng=
 ```
 ```json title="Sandbox User Email"
 test@example.com

--- a/docs/acceptance-guide.mdx
+++ b/docs/acceptance-guide.mdx
@@ -29,7 +29,7 @@ You will need an API key and an email and/or phone for each user. Below is a val
 If you use these suggested test email and/or phone values you can authenticate to the wallet using those values, i.e. richard@piedpiper.net, using a static OTP of `111111`.
 
 ```text title="Sandbox API Key"
-5YugDQgjPn2LG2xTAs/+c6Kfrf7Ie45PIGjJurP8vNk=
+yVg3LEnF08y0MDmpHcPxB+sZWFcDARmPRKdY2M906ng=
 ```
 
 ```text title="Sandbox URL"

--- a/docs/issuance-guide.mdx
+++ b/docs/issuance-guide.mdx
@@ -26,7 +26,7 @@ You will need an API key and an email and/or phone for each user. Below is a val
 If you use these suggested test email and/or phone values you can authenticate to the wallet using those values, i.e. richard@piedpiper.net, using a static OTP of `111111`.
 
 ```text title="Sandbox API Key"
-5YugDQgjPn2LG2xTAs/+c6Kfrf7Ie45PIGjJurP8vNk=
+yVg3LEnF08y0MDmpHcPxB+sZWFcDARmPRKdY2M906ng=
 ```
 
 ```text title="Sandbox URL"


### PR DESCRIPTION
## Summary
Realized we had the wrong Hooli api key listed in the docs which was likely confusing acceptors. We have had to share the hooli "partner" api key with them directly but the docs list a different api key. Oddly, the doc's api key did not match the "Hooli Docs" brand in the db. This change fixes that.

## Changes
- updated the published api key

## Testing
- locally

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [x] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [x] Any dependent changes have been merged and published in upstream projects